### PR TITLE
plot.tree.lines with per‑tip colours and optional tip.size

### DIFF
--- a/plot.tree.lines.R
+++ b/plot.tree.lines.R
@@ -1,5 +1,6 @@
 plot.tree.lines <- function(tree, rotation.angle = 0, x.offset = 0, y.offset = 0, log.scale = F, 
-                            line.type = "s", plot.new = F, show.tip.labels = F, ...){
+                            line.type = "s", plot.new = F, show.tip.labels = F, tips.colour = "black", tip.size = 0.4,
+			    ...){
     rotate <- function(v, angle){
         tmatrix <- matrix(c(cos(angle), -sin(angle), sin(angle), cos(angle)), 2, 2, byrow=T)
         return(tmatrix %*% v)
@@ -33,8 +34,14 @@ plot.tree.lines <- function(tree, rotation.angle = 0, x.offset = 0, y.offset = 0
           c(ordinates_rotated$y.coord[ordinate_start], ordinates_rotated$y.coord[ordinate_end]),
           col = "darkgrey", lwd = 2, type = line.type)
   }
+  
   tips <- ordinates_rotated$node.index %in% 1:length(tree$tip.label)
-  points(ordinates_rotated$x.coord[tips], ordinates_rotated$y.coord[tips], col = "darkgrey", pch = 20, cex = 0.4)
+  if (length(tips.colour) != sum(tips))
+	  tips.colour <- rep(tips.colour, length.out = sum(tips))
+    points(ordinates_rotated$x.coord[tips],
+	   ordinates_rotated$y.coord[tips],
+	   col = tips.colour, pch = 20, cex = tip.size)
+    
   if(show.tip.labels){
     text(ordinates_rotated$x.coord[tips], ordinates_rotated$y.coord[tips], labels = tree$tip.label, pos = 3, cex = 0.6)
   }


### PR DESCRIPTION
Added the option of checking if the number of colours in a given vector if colours is less than the tips. If yes repeats the colour vector. 

Added also the argument tip.size to control the tip size.


#Example of vector
## Define explicit per‑tip colours
n_tips <- length(tree$tip.label)

# Knowing the exact order of the tips in a tree and where the colours go, a vector could be created like this
tip_colors_tree <- c(rep("orange", 41),
                         rep("purple", n_tips - 41))
